### PR TITLE
Fix chat CSS & buzzy beetle behavior

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -484,16 +484,18 @@ hr {
   white-space: nowrap;
 }
 
+#gameChat {
+  width: 25vh;
+}
+
 .container-gameChat {
   position: absolute;
   font-family: SmbWeb;
-  width: 50vh;
-  height: 45vh;
+  width: inherit;
   background-color: #00000080;
-  transform: translateX(5%) translateY(110%);
 
-  top: 0%;
-  left: 0%;
+  bottom: 0.5vw;
+  left: 0.5vw;
 
   background-image: none;
   border-radius: 10px;
@@ -501,6 +503,8 @@ hr {
   overflow-x: clip;
   overflow-y: hidden;
   color: #FFFFFF;
+  
+  font-size: 1vw;
 }
 
 .container-hideChat {
@@ -517,35 +521,29 @@ hr {
 }
 
 .container-chatTab {
-  display:inline-flex;
-  margin-left: -12%;
-  position: absolute;
-  transform: translateY(-50%);
+  display: inline-flex;
+  margin: 0 0.5vw;
 }
 
 .container-chatInput {
-  width: 98%;
-  transform: translateX(-12.5%) translateY(28vh);
-  height: 3vh;
+  width: 95%;
   background-color: rgba(0, 0, 0, 0.565);
   border-radius: 7px;
   font-family: SmbChat;
   color: rgb(255, 255, 255);
-  font-size: 18px;
+  font-size: 1vw;
+  margin: .5vw;
 }
 
 .container-chatMessages {
-  height: 27vh;
+  height: 10vw;
   font-family: 'SmbChat';
-  margin-top: -5vh;
-  margin-left: .5vh;
-  margin-right: .5vh;
+  margin-left: 0.5vw;
+  margin-right: 0.5vw;
   overflow-x: auto;
   white-space: pre-wrap;
-  white-space: -moz-pre-wrap;
-  white-space: -pre-wrap;
-  white-space: -o-pre-wrap;
   word-wrap: break-word;
+  font-size: 0.75vw;
 }
 
 .container-privLobby {

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@MRoyalePlus" />
 
-  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.0'>
+  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.1'>
 
   <script>
     /* Prevent phones from zooming screen. The webapp handles this. */
@@ -438,15 +438,15 @@
     </div>
     <div class="link-l">
       <div class="rtfpn2"></div>
-      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.0')" style="display:none;">v4.6.0
+      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.1')" style="display:none;">v4.6.1
         Patch Notes</div>
     </div>
     <div class="link-b">
       <div class="rtfpn"></div>
       <div>
         <div class="link-leaderboard" onclick="showLeaderBoard();toggleRefresh();">Leaderboards</div>
-        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.0')"></div>
-        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.0')"></div> -->
+        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.1')"></div>
+        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.1')"></div> -->
       </div>
     </div>
     <div class="link-s">
@@ -464,7 +464,7 @@
   <script src='js/lib/cookie/js.cookie.min.js'></script>
 
   <!-- Core -->
-  <script src='js/core.js?v=4.6.0'></script>
+  <script src='js/core.js?v=4.6.1'></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@MRoyalePlus" />
 
-  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.1'>
+  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.2'>
 
   <script>
     /* Prevent phones from zooming screen. The webapp handles this. */
@@ -443,15 +443,15 @@
     </div>
     <div class="link-l">
       <div class="rtfpn2"></div>
-      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.1')" style="display:none;">v4.6.1
+      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.2')" style="display:none;">v4.6.2
         Patch Notes</div>
     </div>
     <div class="link-b">
       <div class="rtfpn"></div>
       <div>
         <div class="link-leaderboard" onclick="showLeaderBoard();toggleRefresh();">Leaderboards</div>
-        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.1')"></div>
-        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.1')"></div> -->
+        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.2')"></div>
+        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.2')"></div> -->
       </div>
     </div>
     <div class="link-s">
@@ -469,7 +469,7 @@
   <script src='js/lib/cookie/js.cookie.min.js'></script>
 
   <!-- Core -->
-  <script src='js/core.js?v=4.6.1'></script>
+  <script src='js/core.js?v=4.6.2'></script>
 </body>
 
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -4900,21 +4900,38 @@ GoombaObject.prototype.control = function () {
 GoombaObject.prototype.physics = function () {
     this.grounded && (this.fallSpeed = 0x0);
     this.fallSpeed = Math.max(this.fallSpeed - GoombaObject.FALL_SPEED_ACCEL, -GoombaObject.FALL_SPEED_MAX);
-    var _0x482f3b = vec2.add(this.pos, vec2.make(this.moveSpeed, 0x0)),
-        _0x443a52 = vec2.add(this.pos, vec2.make(this.moveSpeed, this.fallSpeed)),
-        _0x44dd07 = vec2.make(0x0 <= this.moveSpeed ? this.pos.x : this.pos.x + this.moveSpeed, 0x0 >= this.fallSpeed ? this.pos.y : this.pos.y + this.fallSpeed),
-        _0x39b88d = vec2.make(this.dim.y + Math.abs(this.moveSpeed), this.dim.y + Math.abs(this.fallSpeed)),
-        _0x44dd07 = this.game.world.getZone(this.level, this.zone).getTiles(_0x44dd07, _0x39b88d),
-        _0x39b88d = vec2.make(0x1, 0x1),
-        _0x5c888e = false;
+  
+    var movx = vec2.add(this.pos, vec2.make(this.moveSpeed, 0.));
+    var movy = vec2.add(this.pos, vec2.make(this.moveSpeed, this.fallSpeed));
+
+    var ext1 = vec2.make(this.moveSpeed>=0?this.pos.x:this.pos.x+this.moveSpeed, this.fallSpeed<=0?this.pos.y:this.pos.y+this.fallSpeed);
+    var ext2 = vec2.make(this.dim.y+Math.abs(this.moveSpeed), this.dim.y+Math.abs(this.fallSpeed));
+    var tiles = this.game.world.getZone(this.level, this.zone).getTiles(ext1, ext2);
+    var tdim = vec2.make(1., 1.);
+
+    var changeDir = false;
     this.grounded = false;
-    for (var _0x3c302a = 0x0; _0x3c302a < _0x44dd07.length; _0x3c302a++) {
-        var _0x1a430b = _0x44dd07[_0x3c302a];
-        _0x1a430b.definition.COLLIDE && squar.intersection(_0x1a430b.pos, _0x39b88d, _0x482f3b, this.dim) && (this.pos.x <= _0x482f3b.x && _0x482f3b.x + this.dim.x > _0x1a430b.pos.x ? (_0x482f3b.x = _0x1a430b.pos.x - this.dim.x, _0x443a52.x = _0x482f3b.x, this.moveSpeed = 0x0, _0x5c888e = true) : this.pos.x >= _0x482f3b.x && _0x482f3b.x < _0x1a430b.pos.x + _0x39b88d.x && (_0x482f3b.x = _0x1a430b.pos.x + _0x39b88d.x, _0x443a52.x = _0x482f3b.x, this.moveSpeed = 0x0, _0x5c888e = true));
+  
+    for(var i=0;i<tiles.length;i++) {
+        var tile = tiles[i];
+        if(!tile.definition.COLLIDE) { continue; }
+
+        var hity = squar.intersection(tile.pos, tdim, movy, this.dim);
+
+        if(hity) {
+            if(this.pos.y >= movy.y && movy.y < tile.pos.y + tdim.y) {
+                movy.y = tile.pos.y + tdim.y;
+                this.fallSpeed = 0;
+                this.grounded = true;
+            }
+            else if(this.pos.y <= movy.y && movy.y + this.dim.y > tile.pos.y) {
+                movy.y = tile.pos.y - this.dim.y;
+                this.fallSpeed = 0;
+            }
+        }
     }
-    for (_0x3c302a = 0x0; _0x3c302a < _0x44dd07.length; _0x3c302a++) _0x1a430b = _0x44dd07[_0x3c302a], _0x1a430b.definition.COLLIDE && squar.intersection(_0x1a430b.pos, _0x39b88d, _0x443a52, this.dim) && (this.pos.y >= _0x443a52.y && _0x443a52.y < _0x1a430b.pos.y + _0x39b88d.y ? (_0x443a52.y = _0x1a430b.pos.y + _0x39b88d.y, this.fallSpeed = 0x0, this.grounded = true) : this.pos.y <= _0x443a52.y && _0x443a52.y + this.dim.y > _0x1a430b.pos.y && (_0x443a52.y = _0x1a430b.pos.y - this.dim.y, this.fallSpeed = 0x0));
-    this.pos = vec2.make(_0x482f3b.x, _0x443a52.y);
-    _0x5c888e && (this.dir = !this.dir);
+    this.pos = vec2.make(movx.x, movy.y);
+    if(changeDir) { this.dir = !this.dir; }
 };
 GoombaObject.prototype.sound = GameObject.prototype.sound;
 GoombaObject.prototype.proximity = function () {

--- a/js/scripts/beetle.js
+++ b/js/scripts/beetle.js
@@ -84,10 +84,14 @@ BeetleObject.prototype.step = function () {
         0x0 > this.pos.y && this.destroy();
     }
 };
-BeetleObject.prototype.control = function () {
-    this.state === BeetleObject.STATE.RUN && (this.grounded && !this.checkGround() && (this.dir = !this.dir), this.moveSpeed = this.dir ? -KoopaObject.MOVE_SPEED_MAX : KoopaObject.MOVE_SPEED_MAX);
-    this.state === BeetleObject.STATE.SPIN && (this.moveSpeed = this.dir ? -KoopaObject.SHELL_MOVE_SPEED_MAX : KoopaObject.SHELL_MOVE_SPEED_MAX);
-    if (this.state === BeetleObject.STATE.SHELL || this.state === BeetleObject.STATE.TRANSFORM) this.moveSpeed = 0x0;
+BeetleObject.prototype.control = function() {
+    if (this.state === BeetleObject.STATE.RUN) { 
+        this.moveSpeed = this.dir ? -KoopaObject.MOVE_SPEED_MAX : KoopaObject.MOVE_SPEED_MAX; 
+    } else if (this.state === BeetleObject.STATE.SPIN) { 
+        this.moveSpeed = this.dir ? -KoopaObject.SHELL_MOVE_SPEED_MAX : KoopaObject.SHELL_MOVE_SPEED_MAX; 
+    } else if (this.state === BeetleObject.STATE.SHELL || this.state === BeetleObject.STATE.TRANSFORM) { 
+        this.moveSpeed = 0; 
+    }
 };
 BeetleObject.prototype.physics = function () {
     if (this.grounded) {

--- a/patch.html
+++ b/patch.html
@@ -13,17 +13,17 @@
   <meta property="og:description" content="Mario Royale Patch Notes" />
   <meta name="twitter:description" content="Mario Royale Patch Notes" />
 
-  <link rel='icon' href='https://raw.githubusercontent.com/mroyale/assets/master/img/home/icon.ico'>
+  <link rel='icon' href='https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/icon.ico'>
   <link rel="shortcut icon" type="image/x-icon"
-    href="https://raw.githubusercontent.com/mroyale/assets/master/img/home/icon.ico" />
+    href="https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/icon.ico" />
   <link rel="apple-touch-icon" sizes="192x192"
-    href="https://raw.githubusercontent.com/mroyale/assets/master/img/home/android-chrome-192x192.png">
+    href="https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/android-chrome-192x192.png">
   <meta name="og:image"
-    content="https://raw.githubusercontent.com/mroyale/assets/master/img/home/android-chrome-192x192.png">
+    content="https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/android-chrome-192x192.png">
   <meta property="og:image"
-    content="https://raw.githubusercontent.com/mroyale/assets/master/img/home/android-chrome-192x192.png">
+    content="https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/android-chrome-192x192.png">
   <meta name="twitter:image"
-    content="https://raw.githubusercontent.com/mroyale/assets/master/img/home/android-chrome-192x192.png">
+    content="https://raw.githubusercontent.com/mroyale/assets/legacy/img/home/android-chrome-192x192.png">
   <link rel="stylesheet" type="text/css" href="css/patch.css">
 </head>
 

--- a/patch.html
+++ b/patch.html
@@ -32,10 +32,19 @@
 
     <body>
       <div class="chng">
+        <h1>Version 4.6.2</h1>
+        2023-01-07 - Content Patch<br/>
+        HAPPY NEW YEAR!!!<br/>
+        New world: Sand Dunes
+        <div class="note">Created by Pyriel</div>
+        Buzzy beetles can now walk off cliffs like in the original games
+        Fixed chat so the text box doesn't get cut off in small windows
+        <div class="note">No more zooming out to chat!</div>
+        
         <h1>Version 4.6.1</h1>
         2022-12-20 - Content Patch<br/>
         New world: Special 8<br/>
-        Buzzy beetles can now walk off cliffs like in the original games
+        <div class="note">Created by Clippy</div>
         
         <h1>Version 4.6.0</h1>
         2022-09-22 - Final Legacy Update<br/>

--- a/patch.html
+++ b/patch.html
@@ -32,12 +32,14 @@
 
     <body>
       <div class="chng">
+        <h1>Version 4.6.1</h1>
+        2022-12-20 - Content Patch<br/>
+        New world: Special 8<br/>
+        Buzzy beetles can now walk off cliffs like in the original games
         
         <h1>Version 4.6.0</h1>
         2022-09-22 - Final Legacy Update<br/>
         The GitHub repositories under the mroyale organization have been updated to the last version and have been archived.<br/>
-        <!--Added Mega World 1<br/>
-        Added Special 8-->
         <hr/>
         
         <h1>Version 4.5.3.4</h1>


### PR DESCRIPTION
Buzzy beetles now walk off cliffs like in the original games, i.e. they're fireball-immune **green** koopas (like in the original games) instead of red koopas (what they were in MRL until now). This has been a Legacy pet peeve of mine ever since buzzy beetles were added. I suppose it works better in SMB 8-1 but it messes with Special 8-1. Partially backported from MR Deluxe but with careful checking to match Legacy's conventions — e.g. unlike Deluxe, Legacy inherits some buzzy attributes from KoopaObject.

I know the Deluxe beta is going on right now so it's okay if there's a delay in accepting this.