### PR TITLE
Version 4.6.3

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -478,7 +478,7 @@ hr {
   padding: 0 0 0 0;
 
   position: absolute;
-  top: 90%;
+  top: 80%;
   left: 50%;
   transform: translateX(-50%) translateY(-90%);
   white-space: nowrap;

--- a/css/index.css
+++ b/css/index.css
@@ -485,7 +485,7 @@ hr {
 }
 
 #gameChat {
-  width: 25vh;
+  width: 25vw;
 }
 
 .container-gameChat {

--- a/editor.html
+++ b/editor.html
@@ -488,11 +488,11 @@
       </div>
       
       <!-- Libs -->
-      <script src='js/lib/jquery/jquery-3.6.0.min.js?v=4.4.1'></script>
-      <script src='js/lib/cookie/js.cookie.min.js?v=4.4.1'></script>
+      <script src='js/lib/jquery/jquery-3.6.0.min.js?v=4.6.3'></script>
+      <script src='js/lib/cookie/js.cookie.min.js?v=4.6.3'></script>
       
       <!-- Core -->
-      <script src='js/editor.js?v=4.4.1'></script>
+      <script src='js/editor.js?v=4.6.3'></script>
 
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@MRoyalePlus" />
 
-  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.2'>
+  <link rel='stylesheet' type='text/css' href='css/index.css?v=4.6.3'>
 
   <script>
     /* Prevent phones from zooming screen. The webapp handles this. */
@@ -443,15 +443,15 @@
     </div>
     <div class="link-l">
       <div class="rtfpn2"></div>
-      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.2')" style="display:none;">v4.6.2
+      <div id="link-patch" class="link-patch" onclick="window.open('/patch.html?v=4.6.3')" style="display:none;">v4.6.3
         Patch Notes</div>
     </div>
     <div class="link-b">
       <div class="rtfpn"></div>
       <div>
         <div class="link-leaderboard" onclick="showLeaderBoard();toggleRefresh();">Leaderboards</div>
-        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.2')"></div>
-        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.2')"></div> -->
+        <div class="link-editor" onclick="window.open('/editor.html?v=4.6.3')"></div>
+        <!-- <div class="link-con" onclick="window.open('/control.html?v=4.6.3')"></div> -->
       </div>
     </div>
     <div class="link-s">
@@ -469,7 +469,7 @@
   <script src='js/lib/cookie/js.cookie.min.js'></script>
 
   <!-- Core -->
-  <script src='js/core.js?v=4.6.2'></script>
+  <script src='js/core.js?v=4.6.3'></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
   <!-- Hidden Chat -->
   <div id="hiddenChat">
     <div class="container-gameChat">
-      <h2 style="margin-left: 1vw; margin-right: 1vw;>Show Chat</h2>
+      <h2 style="margin-left: 1vw; margin-right: 1vw;">Show Chat</h2>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
   </div>
 
   <!-- Hidden Chat -->
-  <div id="hiddenChat" style='display:none;'>
+  <div id="hiddenChat">
     <div class="container-gameChat">
       <h2 style="margin-left: 1vw; margin-right: 1vw;>Show Chat</h2>
     </div>
@@ -405,9 +405,9 @@
         <div id="squadBtn">Squad</div>
       </span>
       <hr style="width:95%">
-      <input class="container-chatInput" id="chat-input" maxlength="100">
       <pre id="messagesGlobal" class="container-chatMessages"></pre>
       <pre id="messagesSquad" class="container-chatMessages" style="display:none"></pre>
+      <input class="container-chatInput" id="chat-input" maxlength="100">
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
   </div>
 
   <!-- Hidden Chat -->
-  <div id="hiddenChat">
+  <div id="hiddenChat" style='display:none;'>
     <div class="container-gameChat">
       <h2 style="margin-left: 1vw; margin-right: 1vw;">Show Chat</h2>
     </div>

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
   <!-- Links -->
   <div id='link' style='display:none;'>
     <div class="link-r">
-      <div class="link-git" onclick="window.open('https://github.com/mroyale/mroyale-client')"></div>
+      <div class="link-git" onclick="window.open('https://github.com/mroyale/site')"></div>
       <div class="link-disc" onclick="window.open('https://discord.gg/kV72ezsQwt')"></div>
     </div>
     <div class="link-l">

--- a/js/editor.js
+++ b/js/editor.js
@@ -491,14 +491,14 @@ td32.TILE_PROPERTIES = {
                 /* Touch */
                 case 0x00 : {
                     if(game.pid === pid) {
-						var data = Math.max(0, Math.min(1, parseInt(td.data) || 0));
-						switch (data) {
-							case 1 : { game.getPlayer().kill(); break; }
-							default : { game.getPlayer().damage(); break; }
-						}
+                        var data = Math.max(0, Math.min(1, parseInt(td.data) || 0));
+                        switch (data) {
+                            case 1 : { game.getPlayer().kill(); break; }
+                            default : { game.getPlayer().damage(); break; }
+                        }
                     }
-					break;
-				}
+                    break;
+                }
             }
         }
     },

--- a/js/editor.js
+++ b/js/editor.js
@@ -6,7 +6,7 @@ var tileDefs = {
     1:  {'name': 'SOLID STANDARD'},
     2:  {'name': 'SOLID BUMPABLE'},
     3:  {'name': 'SOLID BREAKABLE NORMAL'},
-    4:  {'name': 'SOLID DAMAGE'},
+    4:  {'name': 'SOLID DAMAGE', 'extraDataName': 'Instant Death (0=off, 1=on)'},
     5:  {'name': 'SEMISOLID'},
     6:  {'name': 'SEMISOLID WEAK'},
     7:  {'name': 'WATER STANDARD'},
@@ -16,7 +16,7 @@ var tileDefs = {
     11: {'name': 'NOTE BLOCK'},
     12: {'name': 'ITEM NOTE BLOCK', 'extraDataName': 'Content', 'extraDataType': 'objId'},
     14: {'name': 'FLIP BLOCK', 'extraDataName': 'Target Data'},
-    15: {'name': 'AIR DAMAGE'},
+    15: {'name': 'AIR DAMAGE', 'extraDataName': 'Instant Death (0=off, 1=on)'},
     13: {'name': 'ICE TILE BLOCK', 'extraDataName': 'Target Tile Data'},
     16: {'name': 'ICE OBJECT BLOCK', 'extraDataName': 'Content', 'extraDataType': 'objId'},
     17: {'name': 'ITEM BLOCK STANDARD', 'extraDataName': 'Content', 'extraDataType': 'objId'},
@@ -57,7 +57,7 @@ var objDefs = {
     19:  {'name': 'KOOPA TROOPA RED', 'description': "- [fly] Should be set to 0 or 1. 1 is flying.\n- [variant] Should be set to 0 or 1. 0 is the light one, 1 is the dark one.", 'paramDefs': [{'name': 'fly','type':'bool'}, {'name': 'variant','type':'bool'}]},
     21:  {'name': 'FLYING FISH', 'description': '- [delay] Positive integer in seconds for how the fish should wait before jumping again.\n- [float] Value for how much force the fish should jump with.', 'paramDefs': [{'name': 'delay','type':'int'}, {'name': 'impulse','type':'float'}]},
     22:  {'name': 'PIRANHA PLANT', 'description': '- [color] Should be set to 0 or 1. 0 is the light one, 1 is the dark one.\n- [direction] Indicates which way to go. 0 is normal, 1 is upside down.\n- [static] Should be 0 or 1. 0 is normal, 1 is static.\n- [noOffset] By default Piranha Plants are offset by half a tile to fit in two tiled pipes. Use 1 to stop that from happening.', 'paramDefs': [{'name': 'variant','type':'bool'}, {'name': 'direction','type':'bool'}, {'name': 'static','type':'bool'}, {'name': 'noOffset','type':'bool'}]},
-    23:  {'name': 'SPINY SHELL', 'description': '- No params.'}, // New
+    23:  {'name': 'SPINY', 'description': '- No params.'}, // New
     24:  {'name': 'BUZZY BEETLE', 'description': '- No params.'},
     25:  {'name': 'BOWSER', 'description': '- [attackType] Should be set to 0, 1 or 2. 0 is only fire breathing, 1 is only hammer throwing, 2 is both.\n- [fireDirection] Should be set to 0 or 1. 0 is left, 1 is right.', 'paramDefs': [{'name': 'attackType','type':'int'}, {'name': 'fireDirection','type':'int'}]},
     33:  {'name': 'FIRE BAR', 'description': '- [phase] Should be only 0 or 1, only offsets it a bit.\n - [length] Positive integer for how many fire balls should spawn\n- [rate] Rate of spinning. Default is 23. Lower is faster, negative is to go in reverse.', 'paramDefs': [{'name': 'phase','type':'bool'}, {'name': 'length','type':'int'}, {'name': 'rate','type':'int'}]},

--- a/js/editor.js
+++ b/js/editor.js
@@ -491,9 +491,14 @@ td32.TILE_PROPERTIES = {
                 /* Touch */
                 case 0x00 : {
                     if(game.pid === pid) {
-                        game.getPlayer().damage();
+						var data = Math.max(0, Math.min(1, parseInt(td.data) || 0));
+						switch (data) {
+							case 1 : { game.getPlayer().kill(); break; }
+							default : { game.getPlayer().damage(); break; }
+						}
                     }
-                }
+					break;
+				}
             }
         }
     },

--- a/js/game.js
+++ b/js/game.js
@@ -478,8 +478,13 @@ td32.TILE_PROPERTIES = {
                 /* Touch */
                 case 0x00: {
                     if (game.pid === pid) {
-                        game.getPlayer().damage();
+                        var data = Math.max(0, Math.min(1, parseInt(td.data) || 0));
+                        switch (data) {
+                            case 1 : { game.getPlayer().kill(); break; }
+                            default : { game.getPlayer().damage(); break; }
+                        }
                     }
+                    break;
                 }
             }
         }
@@ -635,7 +640,7 @@ td32.TILE_PROPERTIES = {
             }
         }
     },
-    /* Non-Solid Damage */
+    /* Air Damage */
     15: {
         COLLIDE: false,
         HIDDEN: false,
@@ -645,8 +650,13 @@ td32.TILE_PROPERTIES = {
                 /* Touch */
                 case 0x00: {
                     if (game.pid === pid) {
-                        game.getPlayer().damage();
+                        var data = Math.max(0, Math.min(1, parseInt(td.data) || 0));
+                        switch (data) {
+                            case 1 : { game.getPlayer().kill(); break; }
+                            default : { game.getPlayer().damage(); break; }
+                        }
                     }
+                    break;
                 }
             }
         }

--- a/js/game.js
+++ b/js/game.js
@@ -9781,6 +9781,8 @@ Game.prototype.doStep = function () {
                     this.gameOver = false;
                     this.gameOverTimer = 0x0;
                     this.lives = -1; // Activate spectate mode
+                    
+                    document.getElementById('return').style.display = "block";
 
                     this.doSpawn();
                     this.getPlayer().spectate();

--- a/js/scripts/beetle.js
+++ b/js/scripts/beetle.js
@@ -84,11 +84,15 @@ BeetleObject.prototype.step = function () {
         0x0 > this.pos.y && this.destroy();
     }
 };
-BeetleObject.prototype.control = function () {
-    this.state === BeetleObject.STATE.RUN && (this.grounded && !this.checkGround() && (this.dir = !this.dir), this.moveSpeed = this.dir ? -KoopaObject.MOVE_SPEED_MAX : KoopaObject.MOVE_SPEED_MAX);
-    this.state === BeetleObject.STATE.SPIN && (this.moveSpeed = this.dir ? -KoopaObject.SHELL_MOVE_SPEED_MAX : KoopaObject.SHELL_MOVE_SPEED_MAX);
-    if (this.state === BeetleObject.STATE.SHELL || this.state === BeetleObject.STATE.TRANSFORM) this.moveSpeed = 0x0;
-};
+BeetleObject.prototype.control = function() {
+    if (this.state === BeetleObject.STATE.RUN) { 
+        this.moveSpeed = this.dir ? -KoopaObject.MOVE_SPEED_MAX : KoopaObject.MOVE_SPEED_MAX; 
+    } else if (this.state === BeetleObject.STATE.SPIN) { 
+        this.moveSpeed = this.dir ? -KoopaObject.SHELL_MOVE_SPEED_MAX : KoopaObject.SHELL_MOVE_SPEED_MAX; 
+    } else if (this.state === BeetleObject.STATE.SHELL || this.state === BeetleObject.STATE.TRANSFORM) { 
+        this.moveSpeed = 0; 
+    }
+}
 BeetleObject.prototype.physics = function () {
     if (this.grounded) {
         this.fallSpeed = 0;

--- a/js/scripts/spiny.js
+++ b/js/scripts/spiny.js
@@ -16,7 +16,7 @@ function SpinyObject(game, level, zone, pos, oid) {
 }
 SpinyObject.ASYNC = false;
 SpinyObject.ID = 0x17;
-SpinyObject.NAME = "SPINY SHELL";
+SpinyObject.NAME = "SPINY";
 SpinyObject.ANIMATION_RATE = 0x5;
 SpinyObject.VARIANT_OFFSET = 0x70;
 SpinyObject.ENABLE_FADE_TIME = 0xf;

--- a/patch.html
+++ b/patch.html
@@ -32,12 +32,24 @@
 
     <body>
       <div class="chng">
+        <h1>Version 4.6.3</h1>
+        2023-01-20 - Content Patch<br/>
+        Buzzy beetles can now walk off cliffs like in the original NES games
+        <div class="note">This was originally in the patch notes for 4.6.2 but the change got reverted by mistake. It's been added for real this time.</div>
+        SOLID DAMAGE and AIR DAMAGE tiles now have an "instant death" option in the level editor
+        <div class="note">
+          Now you can make even harder levels!<br/>
+          Type "1" in the extra data to make damage tiles kill players even if they're powered up.<br/>
+          This will be in Mario Royale Deluxe too.
+        </div>
+        The "Return to Lobby"/"Return to Main" buttons, which pop up when you win, now also appear in spectator mode
+        <hr/>
+        
         <h1>Version 4.6.2</h1>
         2023-01-07 - Content Patch<br/>
         HAPPY NEW YEAR!!!<br/>
         New world: Sand Dunes
         <div class="note">Created by Pyriel</div>
-        Buzzy beetles can now walk off cliffs like in the original games<br/>
         Fixed chat so the text box doesn't get cut off in small windows
         <div class="note">No more zooming out to chat!</div>
         <hr/>

--- a/patch.html
+++ b/patch.html
@@ -37,14 +37,16 @@
         HAPPY NEW YEAR!!!<br/>
         New world: Sand Dunes
         <div class="note">Created by Pyriel</div>
-        Buzzy beetles can now walk off cliffs like in the original games
+        Buzzy beetles can now walk off cliffs like in the original games<br/>
         Fixed chat so the text box doesn't get cut off in small windows
         <div class="note">No more zooming out to chat!</div>
+        <hr/>
         
         <h1>Version 4.6.1</h1>
         2022-12-20 - Content Patch<br/>
         New world: Special 8<br/>
         <div class="note">Created by Clippy</div>
+        <hr/>
         
         <h1>Version 4.6.0</h1>
         2022-09-22 - Final Legacy Update<br/>


### PR DESCRIPTION
* Buzzy beetles can now walk off cliffs like in the original NES games
  * This was originally in the patch notes for 4.6.2 but the change got reverted by mistake. It's been added for real this time.
* SOLID DAMAGE and AIR DAMAGE tiles now have an "instant death" option in the level editor (backported from Deluxe)
* The "Return to Lobby"/"Return to Main" buttons, which pop up when you win, now also appear in spectator mode
  * Moved the buttons up so they don't appear on top of the spectator mode controls
* Renamed "SPINY SHELL" to "SPINY" in the editor